### PR TITLE
Support multiple scopes

### DIFF
--- a/tests/fixtures/multiple-scopes.css
+++ b/tests/fixtures/multiple-scopes.css
@@ -1,0 +1,19 @@
+html {
+  font-size: 12px;
+}
+
+body {
+  font-size: 12px;
+}
+
+:root {
+  font-size: 12px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  color: red;
+}

--- a/tests/fixtures/multiple-scopes.expected.css
+++ b/tests/fixtures/multiple-scopes.expected.css
@@ -1,0 +1,24 @@
+.foo, .bar {
+  font-size: 12px;
+}
+
+.foo, .bar {
+  font-size: 12px;
+}
+
+.foo, .bar {
+  font-size: 12px;
+}
+
+.foo h1,
+.foo h2,
+.foo h3,
+.foo h4,
+.foo h5,
+.bar h1,
+.bar h2,
+.bar h3,
+.bar h4,
+.bar h5 {
+  color: red;
+}

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -80,4 +80,18 @@ describe("postcss-scope", () => {
     expect(actual.css).toEqual(expected);
     expect(actual.warnings()).toHaveLength(0);
   });
+
+  it("should support multiple scopes", async () => {
+    const options = {
+      scope: [".foo", ".bar"],
+    };
+
+    const input = fixture("multiple-scopes");
+    const expected = fixture("multiple-scopes.expected");
+
+    const actual = await process(options, input);
+
+    expect(actual.css).toEqual(expected);
+    expect(actual.warnings()).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Added support for multiple scopes.

### Usage

```javascript
// postcss.config.js

export default {
    plugins: {
        "postcss-scope": [".foo", ".bar"],
    },
};
```