### PR TITLE
Keyframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepublish": "pnpm build"
+    "prepublish": "pnpm build",
+    "test": "jest"
   },
   "keywords": [
     "postcss",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,11 +46,9 @@ function processNode(node: ChildNode, scopes: string[]) {
   }
 
   if (node.type === "rule") {
-    if (/^(body|html|:root)/.test(node.selector)) {
-      node.selector = node.selector.replace(
-        /^(body|html|:root)/,
-        scopes.join(", ")
-      );
+    const rootRegex = /^(body|html|:root)/;
+    if (rootRegex.test(node.selector)) {
+      node.selector = node.selector.replace(rootRegex, scopes.join(", "));
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,9 +40,8 @@ const parse = (scope: string) =>
   });
 
 function processNode(node: ChildNode, scopes: string[]) {
-  if (node.type === "atrule") {
-    node.nodes.forEach((node) => processNode(node, scopes));
-
+  if (node.type === "atrule" && node.name !== "keyframes") {
+    node.nodes?.forEach((n) => processNode(n, scopes));
     return;
   }
 

--- a/tests/fixtures/at-rules.css
+++ b/tests/fixtures/at-rules.css
@@ -1,0 +1,103 @@
+@charset "utf-8";
+
+@container (width > 400px) and (height > 400px) {
+  h2 {
+    font-size: 1.5em;
+  }
+}
+
+@counter-style foo {
+  system: cyclic;
+  symbols: '\1F44D';
+  suffix: ' ';
+}
+
+@font-face {
+  font-family: sans-serif;
+  src: url('') format('woff2');
+}
+
+@font-feature-values Font One {
+  @styleset {
+    nice-style: 12;
+  }
+}
+
+@import url('') print, screen;
+
+@keyframes foo {
+  0% {
+    font-size: 12px;
+  }
+  100% {
+    font-size: 24px;
+  }
+}
+
+@keyframes bar {
+  from {
+    font-size: 12px;
+  }
+  to {
+    font-size: 24px;
+  }
+}
+
+@layer foo {
+  .text-base {
+    font-size: 12px;
+  }
+}
+
+@media screen {
+  .class {
+    font-size: 12px;
+  }
+}
+
+@media screen and (min-width: 900px) {
+  article {
+    padding: 1rem 3rem;
+  }
+}
+
+@supports (display: flex) {
+  @media screen and (min-width: 900px) {
+    article {
+      display: flex;
+    }
+  }
+}
+
+@namespace url(http://www.w3.org/1999/xhtml);
+
+@page {
+  size: 8.5in 9in;
+  margin-top: 4in;
+}
+
+@page :left {
+  margin-top: 4in;
+}
+
+@page wide {
+  size: a4 landscape;
+}
+
+@page {
+  @top-right {
+    content: 'Page ' counter(pageNumber);
+  }
+}
+
+@property --item-size {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 40%;
+}
+
+@supports selector(h2 > p) {
+  .bar {
+    color: red;
+  }
+}

--- a/tests/fixtures/at-rules.expected.css
+++ b/tests/fixtures/at-rules.expected.css
@@ -1,0 +1,103 @@
+@charset "utf-8";
+
+@container (width > 400px) and (height > 400px) {
+  .foo h2 {
+    font-size: 1.5em;
+  }
+}
+
+@counter-style foo {
+  system: cyclic;
+  symbols: '\1F44D';
+  suffix: ' ';
+}
+
+@font-face {
+  font-family: sans-serif;
+  src: url('') format('woff2');
+}
+
+@font-feature-values Font One {
+  @styleset {
+    nice-style: 12;
+  }
+}
+
+@import url('') print, screen;
+
+@keyframes foo {
+  0% {
+    font-size: 12px;
+  }
+  100% {
+    font-size: 24px;
+  }
+}
+
+@keyframes bar {
+  from {
+    font-size: 12px;
+  }
+  to {
+    font-size: 24px;
+  }
+}
+
+@layer foo {
+  .foo .text-base {
+    font-size: 12px;
+  }
+}
+
+@media screen {
+  .foo .class {
+    font-size: 12px;
+  }
+}
+
+@media screen and (min-width: 900px) {
+  .foo article {
+    padding: 1rem 3rem;
+  }
+}
+
+@supports (display: flex) {
+  @media screen and (min-width: 900px) {
+    .foo article {
+      display: flex;
+    }
+  }
+}
+
+@namespace url(http://www.w3.org/1999/xhtml);
+
+@page {
+  size: 8.5in 9in;
+  margin-top: 4in;
+}
+
+@page :left {
+  margin-top: 4in;
+}
+
+@page wide {
+  size: a4 landscape;
+}
+
+@page {
+  @top-right {
+    content: 'Page ' counter(pageNumber);
+  }
+}
+
+@property --item-size {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 40%;
+}
+
+@supports selector(h2 > p) {
+  .foo .bar {
+    color: red;
+  }
+}

--- a/tests/fixtures/multiple-scopes.css
+++ b/tests/fixtures/multiple-scopes.css
@@ -17,3 +17,11 @@ h4,
 h5 {
   color: red;
 }
+
+@media screen {
+  div,
+  #id,
+  .class {
+    font-size: 12px;
+  }
+}

--- a/tests/fixtures/multiple-scopes.expected.css
+++ b/tests/fixtures/multiple-scopes.expected.css
@@ -22,3 +22,14 @@
 .bar h5 {
   color: red;
 }
+
+@media screen {
+  .foo div,
+  .foo #id,
+  .foo .class,
+  .bar div,
+  .bar #id,
+  .bar .class {
+    font-size: 12px;
+  }
+}

--- a/tests/fixtures/multiple-selectors.css
+++ b/tests/fixtures/multiple-selectors.css
@@ -5,3 +5,11 @@ h4,
 h5 {
   color: red;
 }
+
+@media screen {
+  div,
+  #id,
+  .class {
+    font-size: 12px;
+  }
+}

--- a/tests/fixtures/multiple-selectors.expected.css
+++ b/tests/fixtures/multiple-selectors.expected.css
@@ -5,3 +5,11 @@
 .foo h5 {
   color: red;
 }
+
+@media screen {
+  .foo div,
+  .foo #id,
+  .foo .class {
+    font-size: 12px;
+  }
+}

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -67,6 +67,20 @@ describe("postcss-scope", () => {
     expect(actual.warnings()).toHaveLength(0);
   });
 
+  it("should scope at-rules", async () => {
+    const options = {
+      scope: ".foo",
+    };
+
+    const input = fixture("at-rules");
+    const expected = fixture("at-rules.expected");
+
+    const actual = await process(options, input);
+
+    expect(actual.css).toEqual(expected);
+    expect(actual.warnings()).toHaveLength(0);
+  });
+
   it("should scope multiple selectors", async () => {
     const options = {
       scope: ".foo",


### PR DESCRIPTION
This PR improves at-rule handing to fix two issues in particular:

1. `@keyframes` states (percent/`from`/`to`) were being scoped, resulting in `0%` becoming invalid `.foo 0%` for example
2. At-rules like `@charset` with no nodes would cause `TypeError: Cannot read properties of undefined` 